### PR TITLE
feat: Docker 镜像不存在时增加搜索候选与 Hub 跳转

### DIFF
--- a/src/app/api/docker/search/route.ts
+++ b/src/app/api/docker/search/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('q');
+
+    if (!query) {
+      return NextResponse.json(
+        { error: '搜索关键词是必需的' },
+        { status: 400 }
+      );
+    }
+
+    const dockerHubUrl = `https://registry.hub.docker.com/v2/search/repositories?query=${encodeURIComponent(query)}&page_size=5`;
+
+    const response = await fetch(dockerHubUrl, {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; OffDown/1.0)',
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Docker Hub 搜索 API 响应错误: ${response.status}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data, {
+      status: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
+
+  } catch (error) {
+    console.error('Docker 搜索代理错误:', error);
+    return NextResponse.json(
+      { error: '服务器内部错误' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/src/features/docker/api/DockerService.ts
+++ b/src/features/docker/api/DockerService.ts
@@ -1,4 +1,4 @@
-import { DockerImageInfo, DockerManifest } from "@/features/docker/types";
+import { DockerImageInfo, DockerManifest, DockerSearchResult } from "@/features/docker/types";
 import { get } from "@/shared/lib/http";
 import { TarBuilder } from "@/features/docker/utils/tarBuilder";
 
@@ -64,19 +64,36 @@ class DockerService {
   }
 
   async getTagList(imageInfo: DockerImageInfo): Promise<string[]> {
-    try {
-      // 使用代理 API 避免 CORS 问题
-      const namespace = imageInfo.namespace || 'library';
-      const url = `/api/docker/tags?namespace=${namespace}&repository=${imageInfo.repository}`;
-      
-      const response = await get(url, {});
-      const tags = response.data.results.map((tag: any) => tag.name);
-      
-      return tags;
-    } catch (error) {
-      console.warn('获取标签列表失败:', error);
-      return [imageInfo.tag || 'latest'];
+    const namespace = imageInfo.namespace || 'library';
+    const url = `/api/docker/tags?namespace=${namespace}&repository=${imageInfo.repository}`;
+
+    const response = await get(url, {});
+    const results = response.data.results;
+
+    if (!results || results.length === 0) {
+      throw new Error(`镜像 ${namespace}/${imageInfo.repository} 不存在或没有可用标签`);
     }
+
+    return results.map((tag: any) => tag.name);
+  }
+
+  async searchImages(query: string): Promise<DockerSearchResult[]> {
+    try {
+      const url = `/api/docker/search?q=${encodeURIComponent(query)}`;
+      const response = await get(url, {});
+      return response.data.results || [];
+    } catch (error) {
+      console.warn('搜索镜像失败:', error);
+      return [];
+    }
+  }
+
+  getDockerHubUrl(imageInfo: DockerImageInfo): string {
+    const namespace = imageInfo.namespace || 'library';
+    if (namespace === 'library') {
+      return `https://hub.docker.com/_/${imageInfo.repository}`;
+    }
+    return `https://hub.docker.com/r/${namespace}/${imageInfo.repository}`;
   }
 
   async getManifest(imageInfo: DockerImageInfo): Promise<DockerManifest> {

--- a/src/features/docker/components/DockerDownloader.tsx
+++ b/src/features/docker/components/DockerDownloader.tsx
@@ -10,8 +10,9 @@ import {
 import { useToast } from "@/hooks/useToast";
 import { Card, CardContent } from "@/shared/ui/card";
 import { LoadingSpinner } from "@/shared/ui/loading-spinner";
-import { Download, Container, Info, Archive } from "lucide-react";
+import { Download, Container, Info, Archive, ExternalLink, Search, Star } from "lucide-react";
 import { useDockerDownloader } from "../hooks/useDockerDownloader";
+import { dockerService } from "../api/DockerService";
 
 export default function DockerDownloader() {
   const { toast } = useToast();
@@ -27,6 +28,7 @@ export default function DockerDownloader() {
     handleSubmit,
     handleDownload,
     handlePasteFromClipboard,
+    searchResults,
   } = useDockerDownloader();
 
   const onSubmit = async (e: React.FormEvent) => {
@@ -114,6 +116,54 @@ export default function DockerDownloader() {
         )}
       </Button>
 
+      {searchResults.length > 0 && (
+        <Card className="border border-border/60 bg-secondary/30">
+          <CardContent className="p-5">
+            <div className="flex items-center gap-2 mb-3">
+              <Search className="h-4 w-4 text-muted-foreground" />
+              <p className="text-sm font-medium text-foreground">你是否在找：</p>
+            </div>
+            <div className="space-y-2">
+              {searchResults.map((result) => {
+                const parts = result.repo_name.split('/');
+                const namespace = parts.length > 1 ? parts[0] : 'library';
+                const repo = parts.length > 1 ? parts[1] : parts[0];
+                const hubUrl = namespace === 'library'
+                  ? `https://hub.docker.com/_/${repo}`
+                  : `https://hub.docker.com/r/${namespace}/${repo}`;
+                return (
+                  <div key={result.repo_name} className="flex items-center justify-between gap-2 py-1.5">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium text-foreground truncate">{result.repo_name}</p>
+                        {result.is_official && (
+                          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium shrink-0">官方</span>
+                        )}
+                        {result.star_count > 0 && (
+                          <span className="flex items-center gap-0.5 text-xs text-muted-foreground shrink-0">
+                            <Star className="h-3 w-3" />
+                            {result.star_count}
+                          </span>
+                        )}
+                      </div>
+                      {result.short_description && (
+                        <p className="text-xs text-muted-foreground truncate">{result.short_description}</p>
+                      )}
+                    </div>
+                    <a href={hubUrl} target="_blank" rel="noopener noreferrer" className="shrink-0">
+                      <Button type="button" size="sm" variant="outline" className="gap-1.5 text-xs">
+                        <ExternalLink className="h-3 w-3" />
+                        Docker Hub
+                      </Button>
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {tagList.length > 0 && (
         <div className="space-y-3">
           <label className="text-sm font-medium text-foreground">
@@ -151,6 +201,15 @@ export default function DockerDownloader() {
                   <p className="text-muted-foreground">仓库: {imageInfo.registry}</p>
                   <p className="text-muted-foreground">命名空间: {imageInfo.namespace || 'library'}</p>
                   <p className="text-muted-foreground">标签: {imageInfo.tag}</p>
+                  <a
+                    href={dockerService.getDockerHubUrl(imageInfo)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-primary hover:underline"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    在 Docker Hub 查看
+                  </a>
                 </div>
               </div>
             </CardContent>

--- a/src/features/docker/hooks/useDockerDownloader.ts
+++ b/src/features/docker/hooks/useDockerDownloader.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { dockerService } from "../api/DockerService";
-import { DockerImageInfo, DockerDownloadProgress } from "../types";
+import { DockerImageInfo, DockerDownloadProgress, DockerSearchResult } from "../types";
 import { get } from "@/shared/lib/http";
 
 export function useDockerDownloader() {
@@ -10,6 +10,7 @@ export function useDockerDownloader() {
   const [downloadProgress, setDownloadProgress] = useState<DockerDownloadProgress | null>(null);
   const [loading, setLoading] = useState(false);
   const [downloadUrl, setDownloadUrl] = useState("");
+  const [searchResults, setSearchResults] = useState<DockerSearchResult[]>([]);
 
   // Track current blob URL so we can revoke it on re-download or unmount
   const blobUrlRef = useRef<string>("");
@@ -27,6 +28,7 @@ export function useDockerDownloader() {
     setImageInfo(extracted);
     setTagList([]);
     setDownloadUrl("");
+    setSearchResults([]);
   }, []);
 
   const onTagChange = useCallback(
@@ -82,6 +84,7 @@ export function useDockerDownloader() {
     async (e: React.FormEvent) => {
       e.preventDefault();
       setLoading(true);
+      setSearchResults([]);
 
       try {
         if (!imageUrl) {
@@ -89,12 +92,20 @@ export function useDockerDownloader() {
         }
 
         if (imageInfo && !tagList.length) {
-          const tags = await dockerService.getTagList(imageInfo);
-          setTagList(tags);
-          
-          // 如果当前没有选择tag，自动选择第一个
-          if (!imageInfo.tag && tags.length > 0) {
-            setImageInfo({ ...imageInfo, tag: tags[0] });
+          try {
+            const tags = await dockerService.getTagList(imageInfo);
+            setTagList(tags);
+
+            // 如果当前没有选择tag，自动选择第一个
+            if (!imageInfo.tag && tags.length > 0) {
+              setImageInfo({ ...imageInfo, tag: tags[0] });
+            }
+          } catch (tagError) {
+            // 镜像不存在，尝试搜索候选项
+            const query = imageInfo.repository || imageUrl;
+            const results = await dockerService.searchImages(query);
+            setSearchResults(results);
+            throw tagError;
           }
         }
       } catch (error) {
@@ -212,6 +223,7 @@ export function useDockerDownloader() {
     downloadProgress,
     downloadUrl,
     loading,
+    searchResults,
     onImageUrlChange,
     onTagChange,
     handleSubmit,

--- a/src/features/docker/types.ts
+++ b/src/features/docker/types.ts
@@ -25,6 +25,13 @@ export interface DockerTagInfo {
   tags: string[];
 }
 
+export interface DockerSearchResult {
+  repo_name: string;
+  short_description: string;
+  star_count: number;
+  is_official: boolean;
+}
+
 export interface DockerDownloadProgress {
   layerIndex: number;
   totalLayers: number;


### PR DESCRIPTION
## Summary
- `getTagList()` 不再静默回退到 `['latest']`，镜像不存在时抛出明确错误提示
- 新增 `/api/docker/search` 代理路由，调用 Docker Hub 搜索 API 返回候选镜像
- 解析失败时自动搜索并展示候选列表（含官方标识、star 数、简介及 Docker Hub 链接）
- 镜像信息卡片增加「在 Docker Hub 查看」跳转链接

## Test plan
- [x] 输入不存在的镜像名（如 `ngxin`），确认显示错误提示和候选搜索结果
- [x] 候选结果点击「Docker Hub」按钮能正确跳转到对应页面
- [x] 输入正确的镜像名（如 `nginx`），确认正常解析 tag 列表
- [x] 解析成功后镜像信息卡片中「在 Docker Hub 查看」链接正确跳转
- [x] `npm run build` 构建通过

https://claude.ai/code/session_01TtTVkFKqdLK64CANcafP1V