### PR TITLE
优化移动端自适应样式

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -187,6 +187,8 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-text-size-adjust: 100%;
   }
 
   body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,10 +17,10 @@ export default function Home() {
 
   return (
     <main className="min-h-screen bg-background flex flex-col">
-      <div className="flex-1 mx-auto w-full max-w-3xl px-6 py-12 md:py-16">
+      <div className="flex-1 mx-auto w-full max-w-3xl px-4 sm:px-6 py-8 md:py-16">
         {/* Hero Section */}
-        <div className="text-center mb-10 animate-fade-in">
-          <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-3 tracking-tight">
+        <div className="text-center mb-6 md:mb-10 animate-fade-in">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-foreground mb-2 md:mb-3 tracking-tight">
             OffDown
           </h1>
           <p className="text-base text-muted-foreground max-w-md mx-auto leading-relaxed">
@@ -31,40 +31,41 @@ export default function Home() {
         {/* Main Card */}
         <Card className="shadow-apple-lg border-0 bg-card/80 backdrop-blur-xl rounded-apple-lg overflow-hidden animate-slide-up">
           <CardContent className="p-0">
-            <div className="border-b border-border/40 px-6 pt-6 pb-0">
+            <div className="border-b border-border/40 px-3 sm:px-6 pt-4 sm:pt-6 pb-0">
               <Tabs
                 value={activeTab}
                 onValueChange={setActiveTab}
                 className="w-full"
               >
-                <TabsList className="grid w-full grid-cols-3 bg-secondary/60 backdrop-blur-sm rounded-apple p-1 border border-border/40 h-12">
+                <TabsList className="grid w-full grid-cols-3 bg-secondary/60 backdrop-blur-sm rounded-apple p-1 border border-border/40 h-10 sm:h-12">
                   <TabsTrigger
                     value="vscode"
-                    className="rounded-apple-sm font-medium text-sm py-2.5 px-4 data-[state=active]:bg-background data-[state=active]:shadow-apple-button data-[state=active]:text-foreground transition-all duration-200 gap-2"
+                    className="rounded-apple-sm font-medium text-xs sm:text-sm py-2 sm:py-2.5 px-2 sm:px-4 data-[state=active]:bg-background data-[state=active]:shadow-apple-button data-[state=active]:text-foreground transition-all duration-200 gap-1.5 sm:gap-2"
                   >
-                    <Blocks className="h-4 w-4" />
-                    VSCode 插件
+                    <Blocks className="h-4 w-4 flex-shrink-0" />
+                    <span className="hidden sm:inline">VSCode 插件</span>
+                    <span className="sm:hidden">VSCode</span>
                   </TabsTrigger>
                   <TabsTrigger
                     value="chrome"
-                    className="rounded-apple-sm font-medium text-sm py-2.5 px-4 data-[state=active]:bg-background data-[state=active]:shadow-apple-button data-[state=active]:text-foreground transition-all duration-200 gap-2"
+                    className="rounded-apple-sm font-medium text-xs sm:text-sm py-2 sm:py-2.5 px-2 sm:px-4 data-[state=active]:bg-background data-[state=active]:shadow-apple-button data-[state=active]:text-foreground transition-all duration-200 gap-1.5 sm:gap-2"
                   >
-                    <Globe className="h-4 w-4" />
-                    Chrome 扩展
+                    <Globe className="h-4 w-4 flex-shrink-0" />
+                    Chrome
                   </TabsTrigger>
                   <TabsTrigger
                     value="docker"
-                    className="rounded-apple-sm font-medium text-sm py-2.5 px-4 data-[state=active]:bg-background data-[state=active]:shadow-apple-button data-[state=active]:text-foreground transition-all duration-200 gap-2"
+                    className="rounded-apple-sm font-medium text-xs sm:text-sm py-2 sm:py-2.5 px-2 sm:px-4 data-[state=active]:bg-background data-[state=active]:shadow-apple-button data-[state=active]:text-foreground transition-all duration-200 gap-1.5 sm:gap-2"
                   >
-                    <Container className="h-4 w-4" />
-                    Docker 镜像
+                    <Container className="h-4 w-4 flex-shrink-0" />
+                    Docker
                   </TabsTrigger>
                 </TabsList>
               </Tabs>
             </div>
 
             {/* Tab Content */}
-            <div className="p-6 md:p-8">
+            <div className="p-4 sm:p-6 md:p-8">
               {activeTab === "vscode" && <VSCodeDownloader />}
               {activeTab === "chrome" && <ChromeDownloader />}
               {activeTab === "docker" && <DockerDownloader />}
@@ -73,7 +74,7 @@ export default function Home() {
         </Card>
 
         {/* Footer */}
-        <footer className="text-center mt-10 space-y-2 animate-fade-in">
+        <footer className="text-center mt-6 md:mt-10 space-y-2 animate-fade-in">
           <p className="text-xs text-muted-foreground">解析一下，一下就好</p>
           <p
             className="text-xs text-muted-foreground/70"

--- a/src/features/chrome/components/ChromeDownloader.tsx
+++ b/src/features/chrome/components/ChromeDownloader.tsx
@@ -54,7 +54,7 @@ export default function ChromeDownloader() {
   };
 
   return (
-    <form onSubmit={onSubmit} className="space-y-6">
+    <form onSubmit={onSubmit} className="space-y-4 sm:space-y-6">
       <div className="space-y-3">
         <label className="text-sm font-medium text-foreground">
           Chrome 扩展 URL 或 ID
@@ -87,7 +87,7 @@ export default function ChromeDownloader() {
         <div className="space-y-4">
           {/* Extension Info */}
           <Card className="border border-border/60 bg-secondary/30">
-            <CardContent className="p-5">
+            <CardContent className="p-4 sm:p-5">
               <div className="flex items-start gap-3">
                 <div className="flex-shrink-0 w-9 h-9 rounded-apple-sm bg-primary/10 flex items-center justify-center mt-0.5">
                   <Info className="h-4 w-4 text-primary" />
@@ -107,7 +107,7 @@ export default function ChromeDownloader() {
           </Card>
 
           {/* Download Buttons */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-3">
             <Button
               type="button"
               onClick={() => onDownload('crx')}
@@ -143,7 +143,7 @@ export default function ChromeDownloader() {
 
       {downloadProgress && (
         <Card className="border border-border/60 bg-secondary/30">
-          <CardContent className="p-5">
+          <CardContent className="p-4 sm:p-5">
             <div className="space-y-3">
               <div className="flex justify-between text-sm">
                 <span className="text-foreground font-medium">
@@ -170,9 +170,9 @@ export default function ChromeDownloader() {
 
       {(downloadUrls.crx || downloadUrls.zip) && (
         <Card className="border border-primary/20 bg-primary/5">
-          <CardContent className="p-5 space-y-3">
+          <CardContent className="p-4 sm:p-5 space-y-3">
             {downloadUrls.crx && (
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
                 <div className="flex items-center gap-3 min-w-0">
                   <div className="flex-shrink-0 w-9 h-9 rounded-apple-sm bg-primary/10 flex items-center justify-center">
                     <Package className="h-4 w-4 text-primary" />
@@ -182,7 +182,7 @@ export default function ChromeDownloader() {
                     <p className="text-xs text-muted-foreground">Chrome 原生扩展格式</p>
                   </div>
                 </div>
-                <a href={downloadUrls.crx} download={`${extensionInfo?.id}.crx`} className="flex-shrink-0">
+                <a href={downloadUrls.crx} download={`${extensionInfo?.id}.crx`} className="flex-shrink-0 self-end sm:self-auto">
                   <Button type="button" size="sm" variant="outline" className="gap-1.5">
                     <Download className="h-3.5 w-3.5" />
                     下载
@@ -192,7 +192,7 @@ export default function ChromeDownloader() {
             )}
             {downloadUrls.crx && downloadUrls.zip && <div className="border-t border-border/40" />}
             {downloadUrls.zip && (
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
                 <div className="flex items-center gap-3 min-w-0">
                   <div className="flex-shrink-0 w-9 h-9 rounded-apple-sm bg-primary/10 flex items-center justify-center">
                     <FileArchive className="h-4 w-4 text-primary" />
@@ -202,7 +202,7 @@ export default function ChromeDownloader() {
                     <p className="text-xs text-muted-foreground">解压后可查看源码</p>
                   </div>
                 </div>
-                <a href={downloadUrls.zip} download={`${extensionInfo?.id}.zip`} className="flex-shrink-0">
+                <a href={downloadUrls.zip} download={`${extensionInfo?.id}.zip`} className="flex-shrink-0 self-end sm:self-auto">
                   <Button type="button" size="sm" variant="outline" className="gap-1.5">
                     <Download className="h-3.5 w-3.5" />
                     下载

--- a/src/features/docker/components/DockerDownloader.tsx
+++ b/src/features/docker/components/DockerDownloader.tsx
@@ -70,7 +70,7 @@ export default function DockerDownloader() {
     : 0;
 
   return (
-    <form onSubmit={onSubmit} className="space-y-6">
+    <form onSubmit={onSubmit} className="space-y-4 sm:space-y-6">
       <div className="space-y-3">
         <label className="text-sm font-medium text-foreground">
           Docker 镜像名称或 URL
@@ -187,7 +187,7 @@ export default function DockerDownloader() {
         <div className="space-y-4">
           {/* Image Info */}
           <Card className="border border-border/60 bg-secondary/30">
-            <CardContent className="p-5">
+            <CardContent className="p-4 sm:p-5">
               <div className="flex items-start gap-3">
                 <div className="flex-shrink-0 w-9 h-9 rounded-apple-sm bg-primary/10 flex items-center justify-center mt-0.5">
                   <Info className="h-4 w-4 text-primary" />
@@ -225,7 +225,7 @@ export default function DockerDownloader() {
 
       {downloadProgress && (
         <Card className="border border-border/60 bg-secondary/30">
-          <CardContent className="p-5">
+          <CardContent className="p-4 sm:p-5">
             <div className="space-y-3">
               <div className="flex justify-between text-sm">
                 <span className="text-foreground font-medium">
@@ -249,8 +249,8 @@ export default function DockerDownloader() {
 
       {downloadUrl && (
         <Card className="border border-primary/20 bg-primary/5">
-          <CardContent className="p-5">
-            <div className="flex items-center justify-between">
+          <CardContent className="p-4 sm:p-5">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
               <div className="flex items-center gap-3 min-w-0">
                 <div className="flex-shrink-0 w-9 h-9 rounded-apple-sm bg-primary/10 flex items-center justify-center">
                   <Archive className="h-4 w-4 text-primary" />
@@ -265,7 +265,7 @@ export default function DockerDownloader() {
               <a
                 href={downloadUrl}
                 download={imageInfo ? `${imageInfo.repository}-${imageInfo.tag}.tar` : 'docker-image.tar'}
-                className="flex-shrink-0"
+                className="flex-shrink-0 self-end sm:self-auto"
               >
                 <Button type="button" size="sm" variant="outline" className="gap-1.5">
                   <Download className="h-3.5 w-3.5" />

--- a/src/features/vscode/components/VSCodeDownloader.tsx
+++ b/src/features/vscode/components/VSCodeDownloader.tsx
@@ -44,7 +44,7 @@ export default function VSCodeDownloader() {
   };
 
   return (
-    <form onSubmit={onSubmit} className="space-y-6">
+    <form onSubmit={onSubmit} className="space-y-4 sm:space-y-6">
       <div className="space-y-3">
         <label className="text-sm font-medium text-foreground">
           插件 URL
@@ -98,8 +98,8 @@ export default function VSCodeDownloader() {
 
       {extensionInfo?.version && downloadUrl && (
         <Card className="border border-primary/20 bg-primary/5">
-          <CardContent className="p-5">
-            <div className="flex items-center justify-between">
+          <CardContent className="p-4 sm:p-5">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3">
               <div className="flex items-center gap-3 min-w-0">
                 <div className="flex-shrink-0 w-9 h-9 rounded-apple-sm bg-primary/10 flex items-center justify-center">
                   <Package className="h-4 w-4 text-primary" />
@@ -115,7 +115,7 @@ export default function VSCodeDownloader() {
                 href={downloadUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex-shrink-0"
+                className="flex-shrink-0 self-end sm:self-auto"
               >
                 <Button type="button" size="sm" variant="outline" className="gap-1.5">
                   <Download className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

- 缩小移动端页面内边距和间距，在 `sm` 断点恢复桌面尺寸（`px-4 sm:px-6`、`py-8 md:py-16`）
- Tab 导航在小屏幕缩短标签文字（如 "VSCode 插件" → "VSCode"）、减小字号和内边距，避免文字溢出
- Chrome 下载按钮从固定三列改为移动端单列布局（`grid-cols-1 sm:grid-cols-3`）
- 三个功能的下载结果卡片在窄屏时纵向堆叠，下载按钮右对齐
- 内部卡片 padding 响应式调整（`p-4 sm:p-5`）
- 添加 `-webkit-tap-highlight-color` 和 `text-size-adjust` 优化触屏体验

## Test plan

- [x] 在 Chrome DevTools 移动端模拟器（iPhone SE / 375px）下检查页面布局
- [x] 验证 Tab 切换在小屏幕下文字不溢出、可正常点击
- [x] 测试 Chrome 扩展下载按钮在移动端纵向排列
- [x] 验证下载结果卡片在窄屏下正确堆叠，按钮位置合理
- [x] 在桌面宽屏下确认样式无回归

https://claude.ai/code/session_016rDVvMiBFDmDxtwDf2GC6h