### PR TITLE
feat(docker): improve keyword-not-found UX with selectable candidates

### DIFF
--- a/src/features/docker/api/DockerService.ts
+++ b/src/features/docker/api/DockerService.ts
@@ -81,9 +81,17 @@ class DockerService {
       
       return tags;
     } catch (error) {
-      const serverMessage = (error as { response?: { data?: { error?: string } } })
-        ?.response?.data?.error;
-      if (serverMessage) throw new Error(serverMessage);
+      const response = (error as {
+        response?: { status?: number; data?: { error?: string } };
+      })?.response;
+      const serverMessage = response?.data?.error;
+      if (serverMessage) {
+        const enrichedError = new Error(serverMessage) as Error & {
+          response?: typeof response;
+        };
+        enrichedError.response = response;
+        throw enrichedError;
+      }
       throw error;
     }
   }

--- a/src/features/docker/components/DockerDownloader.tsx
+++ b/src/features/docker/components/DockerDownloader.tsx
@@ -53,6 +53,7 @@ export default function DockerDownloader({
     availablePlatforms,
     selectedPlatform,
     onImageUrlChange,
+    selectSearchCandidate,
     onTagChange,
     onPlatformChange,
     handleSubmit,
@@ -105,7 +106,7 @@ export default function DockerDownloader({
     <form onSubmit={onSubmit} className="space-y-4 sm:space-y-6">
       <div className="space-y-3">
         <p className="text-xs text-muted-foreground">
-          输入镜像名，或前往{" "}
+          输入完整镜像名或 Docker Hub 仓库链接。仅输入关键词会按默认命名空间解析，或前往{" "}
           <a
             href="https://hub.docker.com/search"
             target="_blank"
@@ -118,7 +119,7 @@ export default function DockerDownloader({
         </p>
         <InputWithHistory
           data-testid="docker-input"
-          placeholder="nginx:latest 或 hub.docker.com/r/library/nginx"
+          placeholder="镜像名或 Docker Hub 仓库链接"
           value={imageUrl}
           onChange={onImageUrlChange}
           history={history.items}
@@ -132,6 +133,7 @@ export default function DockerDownloader({
           {[
             { label: "Nginx", value: "nginx:latest" },
             { label: "Redis", value: "redis:alpine" },
+            { label: "Kafka", value: "apache/kafka" },
           ].map((example) => (
             <button
               key={example.label}
@@ -210,6 +212,14 @@ export default function DockerDownloader({
               未找到对应镜像：{imageInfo.namespace || "library"}/
               {imageInfo.repository}
             </div>
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Docker 镜像不能按关键词直接解析。当前输入已按{" "}
+              <span className="font-mono">
+                {imageInfo.namespace || "library"}/{imageInfo.repository}
+              </span>{" "}
+              查找；如果你要找社区镜像，请从候选项选择，或输入类似{" "}
+              <span className="font-mono">apache/kafka</span> 的完整名称。
+            </p>
             <div className="flex flex-wrap items-center gap-3 text-xs">
               <a
                 href={dockerService.getDockerHubSearchUrl(
@@ -243,17 +253,11 @@ export default function DockerDownloader({
                 </p>
                 <div className="space-y-2">
                   {searchCandidates.map((candidate) => (
-                    <a
+                    <div
                       key={`${candidate.namespace}/${candidate.repository}`}
-                      href={dockerService.getDockerHubRepoUrl(
-                        candidate.namespace,
-                        candidate.repository,
-                      )}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block rounded-md border border-border/60 p-3 hover:bg-secondary/60 transition-colors"
+                      className="rounded-md border border-border/60 p-3 transition-colors hover:bg-secondary/60"
                     >
-                      <div className="flex items-start justify-between gap-3 sm:items-center">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div className="min-w-0">
                           <p className="text-sm font-medium text-foreground break-all sm:truncate">
                             {candidate.namespace}/{candidate.repository}
@@ -264,9 +268,30 @@ export default function DockerDownloader({
                             </p>
                           )}
                         </div>
-                        <ExternalLink className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                        <div className="flex shrink-0 items-center gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            onClick={() => selectSearchCandidate(candidate)}
+                            data-testid={`docker-candidate-${candidate.namespace}-${candidate.repository}`}
+                          >
+                            选择
+                          </Button>
+                          <a
+                            href={dockerService.getDockerHubRepoUrl(
+                              candidate.namespace,
+                              candidate.repository,
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex h-9 w-9 items-center justify-center rounded-apple-sm text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+                            aria-label={`打开 ${candidate.namespace}/${candidate.repository} 的 Docker Hub 页面`}
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                          </a>
+                        </div>
                       </div>
-                    </a>
+                    </div>
                   ))}
                 </div>
               </div>

--- a/src/features/docker/hooks/useDockerDownloader.ts
+++ b/src/features/docker/hooks/useDockerDownloader.ts
@@ -3,10 +3,23 @@ import { dockerService } from "../api/DockerService";
 import { DockerImageInfo, DockerManifest, DockerPlatform, DockerDownloadProgress, DockerSearchCandidate } from "../types";
 import { get } from "@/shared/lib/http";
 
-const IMAGE_NOT_FOUND_MESSAGE = "未找到对应镜像，请检查名称或从候选镜像中选择";
-
 function formatPlatform(p: DockerPlatform): string {
   return p.variant ? `${p.os}/${p.architecture}/${p.variant}` : `${p.os}/${p.architecture}`;
+}
+
+function formatImageRef(info: DockerImageInfo | null): string {
+  if (!info?.repository) return "当前输入";
+  return `${info.namespace || "library"}/${info.repository}`;
+}
+
+function getImageNotFoundMessage(
+  info: DockerImageInfo | null,
+  hasCandidates: boolean,
+): string {
+  const nextAction = hasCandidates
+    ? "请从下方候选镜像中选择。"
+    : "请前往 Docker Hub 搜索并输入完整 namespace/repository。";
+  return `未找到 ${formatImageRef(info)}。Docker 输入需要完整镜像名，例如 apache/kafka；${nextAction}`;
 }
 
 export function useDockerDownloader(initialValue?: string) {
@@ -55,8 +68,7 @@ export function useDockerDownloader(initialValue?: string) {
     }
   }, []);
 
-  const onImageUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const newUrl = e.target.value;
+  const setImageInput = useCallback((newUrl: string) => {
     setImageUrl(newUrl);
     setImageInfo(null);
     setTagList([]);
@@ -69,6 +81,20 @@ export function useDockerDownloader(initialValue?: string) {
     setSelectedPlatform("");
     selectedPlatformRef.current = "";
   }, []);
+
+  const onImageUrlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setImageInput(e.target.value);
+    },
+    [setImageInput],
+  );
+
+  const selectSearchCandidate = useCallback(
+    (candidate: DockerSearchCandidate) => {
+      setImageInput(`${candidate.namespace}/${candidate.repository}`);
+    },
+    [setImageInput],
+  );
 
   const onTagChange = useCallback(
     (value: string) => {
@@ -116,6 +142,7 @@ export function useDockerDownloader(initialValue?: string) {
     setImageNotFound(true);
     const candidates = await dockerService.searchImages(searchKeyword, 5);
     setSearchCandidates(candidates);
+    return candidates;
   }, []);
 
   const handleSubmit = useCallback(
@@ -139,8 +166,10 @@ export function useDockerDownloader(initialValue?: string) {
 
           if (!tags.length) {
             const searchKeyword = extracted.repository || imageUrl;
-            await handleImageNotFound(searchKeyword);
-            throw new Error(IMAGE_NOT_FOUND_MESSAGE);
+            const candidates = await handleImageNotFound(searchKeyword);
+            throw new Error(
+              getImageNotFoundMessage(extracted, candidates.length > 0),
+            );
           }
 
           setTagList(tags);
@@ -169,8 +198,10 @@ export function useDockerDownloader(initialValue?: string) {
         const axiosError = error as { response?: { status?: number } };
         if (axiosError?.response?.status === 404) {
           const searchKeyword = extracted?.repository || imageUrl;
-          await handleImageNotFound(searchKeyword);
-          throw new Error(IMAGE_NOT_FOUND_MESSAGE);
+          const candidates = await handleImageNotFound(searchKeyword);
+          throw new Error(
+            getImageNotFoundMessage(extracted, candidates.length > 0),
+          );
         }
         throw error;
       } finally {
@@ -308,6 +339,7 @@ export function useDockerDownloader(initialValue?: string) {
     availablePlatforms,
     selectedPlatform,
     onImageUrlChange,
+    selectSearchCandidate,
     onTagChange,
     onPlatformChange,
     handleSubmit,

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -205,6 +205,40 @@ test("Docker flow supports ARM architecture selection", async ({ page }) => {
   );
 });
 
+test("Docker flow explains keyword-like image parse failures and lets users pick a candidate", async ({
+  page,
+}) => {
+  await mockDockerApis(page, {
+    missingImages: ["library/kafka"],
+    searchResults: [
+      {
+        repo_name: "apache/kafka",
+        short_description: "Apache Kafka is an open-source event streaming platform.",
+        star_count: 1234,
+        pull_count: 123456,
+      },
+    ],
+  });
+
+  await page.goto("/");
+  await page.getByTestId("tab-docker").click();
+
+  await page.getByTestId("docker-input").fill("kafka");
+  await page.getByTestId("docker-submit").click();
+
+  await expect(page.getByText("未找到对应镜像：library/kafka")).toBeVisible();
+  await expect(
+    page.getByText(/Docker 镜像不能按关键词直接解析/),
+  ).toBeVisible();
+  await expect(page.getByTestId("docker-candidate-apache-kafka")).toBeVisible();
+
+  await page.getByTestId("docker-candidate-apache-kafka").click();
+  await expect(page.getByTestId("docker-input")).toHaveValue("apache/kafka");
+
+  await page.getByTestId("docker-submit").click();
+  await expect(page.getByText("选择版本")).toBeVisible();
+});
+
 test("MSStore flow renders a download link from a store URL", async ({
   page,
 }) => {

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -27,6 +27,13 @@ const dockerLayerGzip = gzipSync(Buffer.alloc(1024));
 
 type MockDockerOptions = {
   includeInvalidLayer?: boolean;
+  missingImages?: string[];
+  searchResults?: Array<{
+    repo_name: string;
+    short_description?: string;
+    star_count?: number;
+    pull_count?: number;
+  }>;
 };
 
 function fulfillJson(route: Route, data: unknown, status = 200) {
@@ -128,8 +135,23 @@ export async function mockEdgeApis(page: Page) {
 
 export async function mockDockerApis(page: Page, options: MockDockerOptions = {}) {
   await page.route("**/api/docker/tags**", async (route) => {
+    const url = new URL(route.request().url(), "http://localhost");
+    const namespace = url.searchParams.get("namespace") || "library";
+    const repository = url.searchParams.get("repository") || "";
+
+    if (options.missingImages?.includes(`${namespace}/${repository}`)) {
+      await fulfillJson(route, { error: "not found" }, 404);
+      return;
+    }
+
     await fulfillJson(route, {
       results: [{ name: "latest" }, { name: "alpine" }],
+    });
+  });
+
+  await page.route("**/api/docker/search**", async (route) => {
+    await fulfillJson(route, {
+      results: options.searchResults ?? [],
     });
   });
 


### PR DESCRIPTION
## Summary

- 用户输入模糊时，提示也很模糊，用户会困惑是无法解析站不支持还是真的解析不了
- fix: #19 

## Change Type

- [x] User-visible behavior change
- [ ] API / route / input-output change
- [ ] Internal refactor only
- [ ] Documentation-only

## Doc Sync Checklist

- [x] I checked whether this PR changes product behavior, inputs, outputs, routes, tabs, scripts, or test coverage
- [x] I updated `docs/spec.md` if implementation behavior changed
- [x] I updated `README.md` and `README.zh.md` if the public-facing summary changed
- [x] I updated `docs/api.http` if request examples or API routes changed
- [x] I updated `CLAUDE.md` if agent guidance or implementation constraints changed
- [x] I intentionally made no doc updates because no documented behavior changed

## Verification

- [x] `pnpm lint`
- [x] Relevant tests passed
- [x] Not run, with reason explained below

## Notes

- Risks, follow-ups, or anything reviewers should pay attention to
